### PR TITLE
remove 'module' entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.0",
   "description": "react flickity component",
   "main": "./lib/index.js",
-  "module": "./src/index",
   "scripts": {
     "test": "npm run pretty && jest ./__tests__",
     "pretty": "prettier --single-quote --trailing-comma es5 --write \"src/**/*.js\"",


### PR DESCRIPTION
'module' is creating more trouble than benefits as users would use create-react-app and other similar webpack configs that uses 'module' as first entry point, which causes issue with minifying.