### PR TITLE
fix #34 and #35

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,18 @@ class FlickityComponent extends Component {
       this.props.reloadOnUpdate ||
       (!prevState.flickityReady && this.state.flickityReady)
     ) {
-      this.flkty.reloadCells();
-      this.flkty.resize();
+      this.flkty.deactivate();
+      this.flkty.selectedIndex = this.props.options.initialIndex || 0;
+      this.flkty.options.draggable =
+        this.props.options.draggable === undefined
+          ? this.props.children.length > 1
+          : this.props.options.draggable;
+      imagesloaded(
+        this.carousel,
+        function(instance) {
+          this.flkty.activate();
+        }.bind(this)
+      );
     }
     this.imagesLoaded();
   }

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,9 @@ class FlickityComponent extends Component {
       this.flkty.selectedIndex = this.props.options.initialIndex || 0;
       this.flkty.options.draggable =
         this.props.options.draggable === undefined
-          ? this.props.children.length > 1
+          ? this.props.children
+            ? this.props.children.length > 1
+            : false
           : this.props.options.draggable;
       imagesloaded(
         this.carousel,


### PR DESCRIPTION
These two issues are because  when Flickity is initialized, slider items have not been added to DOM yet, and these two properties actually depend on checking DOM. 
L27 is because of https://github.com/metafizzy/flickity/blob/master/js/flickity.js#L198 
L28-31 is because of https://github.com/metafizzy/flickity/blob/master/js/drag.js#L86-L89

Also we need to re-activate Flickity and activate will do cell 'size and 'locate' so I remove the previous two functions.