### PR TITLE
Relax version check on react peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "sinon": "^7.3.2"
   },
   "peerDependencies": {
-    "react": "~16.0.0",
-    "react-dom": "~16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "jest": {
     "testURL": "http://localhost/"


### PR DESCRIPTION
Currently this only allows v16.0.0, which is too restrictive. Now it will allow v16.x.x.