### PR TITLE
fix server side rendering bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
-import Flickity from 'flickity';
 import imagesloaded from 'imagesloaded';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import PropTypes from 'prop-types';
+const Flickity = typeof window !== "undefined" ? require('flickity') : undefined;
 
 class FlickityComponent extends Component {
   constructor(props) {


### PR DESCRIPTION
fix "ReferenceError: window is not defined" error on SSR project.
in server side 'winodw' object does not exist. we can import 'flickity' package when we need to render slider in client and in server generate pure DOM.