### PR TITLE
[SSR] Fix window undefined bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-flickity-component",
-  "version": "3.3.2",
+  "version": "3.3.1",
   "description": "react flickity component",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "react-flickity-component",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "react flickity component",
   "main": "./lib/index.js",
   "scripts": {
     "test": "npm run pretty && jest ./__tests__",
     "pretty": "prettier --single-quote --trailing-comma es5 --write \"src/**/*.js\"",
-    "prepublishOnly": "babel ./src --out-dir ./lib --source-maps"
+    "prepublishOnly": "babel ./src --out-dir ./lib --source-maps",
+    "develop": "babel ./src --out-dir ./lib --source-maps --watch"
   },
   "author": "theolampert",
   "license": "GPL3",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "test": "npm run pretty && jest ./__tests__",
     "pretty": "prettier --single-quote --trailing-comma es5 --write \"src/**/*.js\"",
-    "prepublishOnly": "babel ./src --out-dir ./lib --source-maps",
-    "develop": "babel ./src --out-dir ./lib --source-maps --watch"
+    "prepublishOnly": "babel ./src --out-dir ./lib --source-maps"
   },
   "author": "theolampert",
   "license": "GPL3",

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,6 @@ class FlickityComponent extends Component {
     const { disableImagesLoaded, flickityRef, options } = this.props;
     const carousel = this.carousel;
     const Flickity = require('flickity');
-
     this.flkty = new Flickity(carousel, options);
     const setFlickityToReady = () => this.setState({ flickityReady: true });
     if (disableImagesLoaded) setFlickityToReady();

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
-import Flickity from 'flickity';
 import imagesloaded from 'imagesloaded';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import PropTypes from 'prop-types';
@@ -43,6 +42,8 @@ class FlickityComponent extends Component {
     if (!canUseDOM) return null;
     const { disableImagesLoaded, flickityRef, options } = this.props;
     const carousel = this.carousel;
+    const Flickity = require('flickity');
+
     this.flkty = new Flickity(carousel, options);
     const setFlickityToReady = () => this.setState({ flickityReady: true });
     if (disableImagesLoaded) setFlickityToReady();


### PR DESCRIPTION
flickity will call window as soon as its imported. In order to use with SSR it must be required on componentDidMount

This fix is confirmed working in Gatsby.
This is a new PR in in lieu of #78 