### PR TITLE
fix #75: `imageloaded` to properly wait on image to resize carousel

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,6 @@ class FlickityComponent extends Component {
   renderPortal() {
     if (!this.carousel) return null;
     const mountNode = this.carousel.querySelector('.flickity-slider');
-    console.log(mountNode)
     if (mountNode) {
       const element = createPortal(this.props.children, mountNode);
       this.setReady();

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ class FlickityComponent extends Component {
     this.state = {
       flickityReady: false,
       flickityCreated: false,
+      cellCount: 0,
     };
 
     this.carousel = null;
@@ -53,6 +54,7 @@ class FlickityComponent extends Component {
   }
 
   setReady() {
+    if (this.state.flickityReady) return;
     const setFlickityToReady = () => this.setState({ flickityReady: true });
     if (this.props.disableImagesLoaded) setFlickityToReady();
     else imagesloaded(this.carousel, setFlickityToReady);
@@ -63,7 +65,10 @@ class FlickityComponent extends Component {
     const mountNode = this.carousel.querySelector('.flickity-slider');
     if (mountNode) {
       const element = createPortal(this.props.children, mountNode);
-      this.setReady();
+      setTimeout(() => this.setReady(), 0);
+      const cellCount = React.Children.count(this.props.children);
+      if (cellCount !== this.state.cellCount)
+        this.setState({ flickityReady: false, cellCount });
       return element;
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ class FlickityComponent extends Component {
 
     this.state = {
       flickityReady: false,
+      flickityCreated: false,
     };
 
     this.carousel = null;
@@ -40,20 +41,32 @@ class FlickityComponent extends Component {
 
   componentDidMount() {
     if (!canUseDOM) return null;
-    const { disableImagesLoaded, flickityRef, options } = this.props;
-    const carousel = this.carousel;
     const Flickity = require('flickity');
-    this.flkty = new Flickity(carousel, options);
-    const setFlickityToReady = () => this.setState({ flickityReady: true });
-    if (disableImagesLoaded) setFlickityToReady();
-    else imagesloaded(carousel, setFlickityToReady);
+    const { flickityRef, options } = this.props;
+    this.flkty = new Flickity(this.carousel, options);
     if (flickityRef) flickityRef(this.flkty);
+    if (this.props.static) {
+      this.setReady();
+    } else {
+      this.setState({ flickityCreated: true });
+    }
+  }
+
+  setReady() {
+    const setFlickityToReady = () => this.setState({ flickityReady: true });
+    if (this.props.disableImagesLoaded) setFlickityToReady();
+    else imagesloaded(this.carousel, setFlickityToReady);
   }
 
   renderPortal() {
     if (!this.carousel) return null;
     const mountNode = this.carousel.querySelector('.flickity-slider');
-    if (mountNode) return createPortal(this.props.children, mountNode);
+    console.log(mountNode)
+    if (mountNode) {
+      const element = createPortal(this.props.children, mountNode);
+      this.setReady();
+      return element;
+    }
   }
 
   render() {


### PR DESCRIPTION
The issue is because before the `imagedloaded` code is in `cDM` life cycle, where the element `carousel` used for watch for imageloaded actually doesn't have any images inside, because we append children in renderPortal function, which happens after `cDM` after a state change. 

The fix is to move this part of logic in `renderPortal` after `carousel` element actually contains images so imageloaded can function properly. To trigger `renderPortal` we need a state change so I add another state `flickityCreated`, and set it to true when we create flickity.

When `static` is set we don't use portal to render, but still we need to change `flickityReady` state.

Currently version works in Chrome larger breakpoints is somewhat lucky. I tried in small breakpoints and it doesn't work either. My wild guess is in these large breakpoints Chrome is doing some optimization on image loading so it actually work