### PR TITLE
Update "slides" type to be array

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,7 +34,7 @@ declare class Flickity extends React.Component<Props, any> {
   public selectedElement: React.ReactNode;
   public selectedElements: React.ReactNode;
   public cells: React.ReactNode;
-  public slides: React.ReactNode;
+  public slides: React.ReactNode[];
   public viewFullscreen(): void;
   public exitFullscreen(): void;
   public toggleFullscreen(): void;


### PR DESCRIPTION
## Description

The slides property of the Flickity object should be an array of ReactNodes. 
_See [issue #112](https://github.com/theolampert/react-flickity-component/issues/112)_

- [Flickity documentation reference](https://flickity.metafizzy.co/api.html#slides)
- Test against reference object:
```typescript
<Flickity flickityRef={({slides}) => console.log(slides)} {...options} />
```